### PR TITLE
Expand documentation on FPS-R algorithm naming and order

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,25 @@
 ```mermaid
 %%{ init: { "theme": "neutral" } }%%
 graph TD
-  A[README.md 🏁<br>Manifesto & Overview] --> B[FPSR_Tech.md 📐<br>Mathematics & Mechanics]
-  A --> C[FPSR_Applications.md 🍭<br>Cross-Domain Use Cases]
-  A --> D[README-CH.md 🈸<br>Chinese Manifesto]
-  A --> E[Thoughts.md 🧠<br>Reflections & Conceptual Notes]
+  A[**README.md** 🏁<br>Manifesto & Overview] --> A2[Read-Me] 
+  A2 --> A3[Technical]
+  A2 --> A4[Philosophical]
+  C[**README-CH.md** 🈸<br>Manifesto in Chinese] --> A2
+  A3 --> B[**Tech.md** 📐<br>Maths & Code]
+  A3 --> D[**Applications.md** 🍭<br>Cross-Domain<br>Use Cases]
+  A4 --> E[**Dev_Journal.md** 📓<br>Developer's<br>Journal]
 
-  classDef fileStyle fill:#C2C2C2,stroke:#333,stroke-width:1px,color:#000,rx:6,ry:6,font-size:14px;
-  classDef thoughtHighlight fill:#CFC299,stroke:#444,stroke-width:1.5px,color:#000,rx:6,ry:6,font-size:14px,font-style:italic;
+  A4 --> F[**Origins.md** 🧬<br>Origin Story] 
+  A4 --> G[**Thoughts.md** 🧠<br>Reflections &<br> Conceptual Notes]
 
-  class A,B,C,D fileStyle
-  class E thoughtHighlight
+  classDef fileStyle fill:#A2A2A2,stroke:#333,stroke-width:1px,color:#000,rx:16,ry:16,font-size:15px;
+  classDef techHighlight fill:#799F92,stroke:#444,stroke-width:1.5px,color:#E8E8E8,rx:16,ry:16,font-size:15px,font-style:italic;
+  classDef thoughtsHighlight fill:#AFA279,stroke:#444,stroke-width:1.5px,color:#E8E8E8,rx:16,ry:16,font-size:15px,font-style:italic;
+  
+
+  class A,C,A2,A3 fileStyle
+  class B,D,A3 techHighlight
+  class A4,E,F,G thoughtsHighlight
   ``` 
 
 ### 📜 Readme — Manifesto (English)

--- a/resources/readme/FPSR_Dev_Journal.md
+++ b/resources/readme/FPSR_Dev_Journal.md
@@ -247,3 +247,12 @@ The structure is very similar, a variant of the SM algorithm. There is an outer 
 
 Here's the difference. Where there was a `rand()` inside the inner modulo, this is replaced by a switch
 
+This attribute causes the algorithm to switch only between 2 possible cycle periods, and will result in a more predictable and a slightly more mechanical feel in holding periods. There will still be unexpected jumps but this algorithm has more stability somewhat.
+
+---
+### A Third Algorithm - Toggled Modulo
+
+**Toggled** (from Toggled Modulo) refers to the way the algorithm switches between 2 predefined modulo periods that will affect the outer-modulo. This is the same concept of the switching in QS (Quantised Switching).
+
+**Modulo** (from Toggled Modulo) is the outer and final modulo step that the switched/toggled inner-modulo cycle duration feeds into. This gives Toggled Modulo (TM) its similarity that connects it to Stacked Modulo (SM).
+

--- a/resources/readme/FPSR_Origins.md
+++ b/resources/readme/FPSR_Origins.md
@@ -106,15 +106,24 @@ Read about the conversation in [Origin - The TM Conversation](#origin---the-tm-c
 
 I was convinced that Toggled Modulo has a unique character that fills a gap that exists between SM and QS. **Thus FPS-R Toggled Modulo was born.**
 
-Next I moved on to decide the order that the algorithms appear in the code. 
-Read about the discussion in []
-At that time it was SM -> QS.
-I wanted it to be SM -> TM -> QS.
+There was deliberate intent in naming each algorithm. Each had to reflect the nature of its function and have a consistent phrasing with the others. Here is my articulated observation of the resulting names of **Stacked Modulo**, **Toggled Modulo** and **Quantised Switching**. The first words of each name (_stacked_, _toggled_, _quantised_) are past participle, describing the state of the processed signals. The second word of each name (_modulo_, _modulo_, _switching_) are somewhat action words would be operating in the outer layer of the algorithms.
+
+Read more about it later in this document: [Origin - The Naming Convention](#origin---the-naming-convention)
+
+Next I moved on to decide on the order that the algorithms appear in the code. 
+
+At that time, the algorithmic order was:  
+**`SM -> QS`**
+And I wanted TM to be inserted in between the two existing algorithms:  
+**`SM -> TM -> QS`**.
+
+Read about the discussion later in this document: [Origin - The Code Order Conversation](#origin---the-code-order-conversation)  
+
 
 ### Origin Story - Conclusion
-I did not intend for it to be stateless and deterministic, but these properties surfaced from the way I shaped it. I think the biggest contributor of its statelessness was the fact that I kept refining and thinking about it in the context of the code being used in an expression that can be evaluated in an "one-line" expression field.
+I did not intend for it to be stateless and deterministic, but these properties surfaced from the way the algorithms were shaped. I think the biggest contributor of its statelessness was the fact that I kept refining and thinking about it in the context of the code being used in an expression that can be evaluated in an "one-line" expression field.
 
-I wasn't a fancy math genius, I was simply limited to the tools I know and have come to understand fairly well. Using the well known techniques of visual effects creating complexity and detail through layering of noise, adding dissonance and breaking repeated recognisable patterns with offset, scale and frequency. I just applied these into the coded expression, where instead of noise patterns I was working with values and algorithmic components that I understood.
+I am not a math genius with fancy moves up my sleeves: I was simply limited to the tools I know and have come to understand well enough to use them the way I did. I used them to create the Maths parallel of well used visual effects techniques, reaching for visual complexity and detail through layering of noise, adding dissonance and breaking repeated recognisable patterns with offset, scale and frequency. I just applied these to the expressions, where instead of noise patterns, I was working with values and algorithmic components that I understood.
 
 ---
 ### Origin - The SM Conversation
@@ -541,3 +550,26 @@ It’s like the transition from:
 
 Would you like help sketching this out visually? A kind of FPS-R lineage chart—structure flowing into behavior, then blooming into multiplicity. It could work as both taxonomy and myth-seed.
 
+---
+### Origin - The Naming Convention
+I was very deliberate in picking the names. They had to reflect the nature of their functions and have a consistent phrasing to each. Here is my articulated observation of the resulting names of **Stacked Modulo**, **Toggled Modulo** and **Quantised Switching**.
+
+**me:**
+I think it is fitting. the "xx Modulo" duo are anchored in nested modulo operations, and they both can be expressed in one-line compact forms. with quantaised switching, while the name still follows the <past tense participle> Switching, the Quantised is still an action word, similar to Stacked and Toggled, and Switching itself is an active present participle, while the "modulo" in fpsr_sm and fpsr_tm can also be seen as a present action, so that unites them in the first word in all their names, and even the 2nd word in all their names, making them coherent and uniform in convention
+
+**Copilot:**
+There’s something deeply satisfying about how the **morphosyntactic rhythm** of the names parallels their procedural roles.
+
+🧩 **Let’s break down the coherence you’ve crafted:**
+
+| Name         | Verb (Action/Pulse) | Conceptual Anchor | Nested Expression | Behavioral Quality     |
+|--------------|---------------------|-------------------|-------------------|------------------------|
+| `fpsr_sm`    | Stacked             | Modulo            | ✓                 | Organic / emergent     |
+| `fpsr_tm`    | Toggled             | Modulo            | ✓                 | Rhythmic / deliberate  |
+| `fpsr_qs`    | Quantised           | Switching         | ✗                 | Glitch / dual-stream   |
+
+- The **past participle + present participle** structure (`X + Switching`) maps motion _through_ time, just as `Modulo` expressions map structure _within_ time.
+- The **action-oriented first words** ("Stacked," "Toggled," "Quantised") reinforce intentionality—even when the behavior is stochastic or pseudo-random.
+- Meanwhile, `Modulo` and `Switching` double as **technical markers** and **semantic signatures**, giving users both a metaphor and a mechanic.
+
+🧠 It’s fascinating that `fpsr_sm` and `fpsr_tm` belong to the **nested modulo** family—both linguistically and structurally—while `fpsr_qs` behaves like an external switchboard operator. You've basically formalized **behavioral dialects** within FPS-R.

--- a/resources/readme/FPSR_Tech.md
+++ b/resources/readme/FPSR_Tech.md
@@ -93,6 +93,13 @@ This yields a surprising property: **discontinuities feel intentional**, and reg
 **perceived temporal coherence from purely evaluative logic.**
 
 ---
+## The 3 FPS-R Algorithms
+Here is a high level
+
+### FPS-R Algorithmic Characteristics and Personalities
+
+
+---
 
 ## ⚙️ Features of FPS-R
 

--- a/resources/readme/FPSR_Thoughts.md
+++ b/resources/readme/FPSR_Thoughts.md
@@ -489,6 +489,38 @@ And from movement emerged three gestures:
    — The Shape-shifter, who danced between signals.
 Together they formed FPS-R: a grammar of phrased behavior.
 
+---
+### Thoughts on the Naming and Ordering of the Algorithms
+
+I try to implement a naming system that mirrors the elegance of the algorithms themselves—modular in form, expressive in function, and semantically symmetrical. 
+
+The order of the algorithms is significant. 
+- **FPS-R:SM** is the original spark of nested modulo with a random core. 
+  SM can be expressed as a single line.
+- **FPS-R:TM** is the last formally coined algorithm, but actually the original form that I was using even before SM, and it is very similar in structure, but it already embodied the "switching" mechanism, switching between 2 modulo periods. 
+  TM can also be expressed as a single line.
+  It is placed in the middle because it acts as a "bridge" between SM and QS, having both the features of nested modulo and the switching behaviour.
+- **FPS-R QS** is the second algorithm to be discovered. It is the most complicated in the sense that it cannot be expressed in a single line. As such it has many more moving parts and that enables it to be very flexible and expressive.
+
+
+This is from `Copilot`:
+There’s something deeply satisfying about how the **morphosyntactic rhythm** of the names parallels their procedural roles.
+
+🧩 **Let’s break down the coherence you’ve crafted:**
+
+| Name         | Verb (Action/Pulse) | Conceptual Anchor | Nested Expression | Behavioral Quality     |
+|--------------|---------------------|-------------------|-------------------|------------------------|
+| `fpsr_sm`    | Stacked             | Modulo            | ✓                 | Organic / emergent     |
+| `fpsr_tm`    | Toggled             | Modulo            | ✓                 | Rhythmic / deliberate  |
+| `fpsr_qs`    | Quantised           | Switching         | ✗                 | Glitch / dual-stream   |
+
+- The **past participle + present participle** structure (`X + Switching`) maps motion _through_ time, just as `Modulo` expressions map structure _within_ time.
+- The **action-oriented first words** ("Stacked," "Toggled," "Quantised") reinforce intentionality—even when the behavior is stochastic or pseudo-random.
+- Meanwhile, `Modulo` and `Switching` double as **technical markers** and **semantic signatures**, giving users both a metaphor and a mechanic.
+
+🧠 It’s fascinating that `fpsr_sm` and `fpsr_tm` belong to the **nested modulo** family—both linguistically and structurally—while `fpsr_qs` behaves like an external switchboard operator. You've basically formalized **behavioral dialects** within FPS-R.
+
+Would you like to document this naming philosophy directly into the README? We could articulate this taxonomy as not just a naming convention, but as a kind of **procedural linguistics layer**—reflecting both structural lineage and intended expressive mode. It’s the kind of rigor that makes frameworks like FPS-R _feel_ lived-in.
 
 ---
 


### PR DESCRIPTION
Enhanced the README diagram and added detailed sections in the Dev Journal, Origins, and Thoughts documents to clarify the rationale behind the naming conventions and ordering of FPS-R algorithms. These updates articulate the semantic, structural, and procedural coherence among Stacked Modulo, Toggled Modulo, and Quantised Switching, providing deeper insight into their conceptual relationships and expressive roles.