### PR TITLE
fixed readme.md where it says there are two flavours of FPS-R, to three

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ The interactive scrolling graphs are the last 2 cells at the end of the notebook
 
 ---
 ## 🧬 Flavours of FPS-R
-FPS-R comprises two distinct mathematical algorithms — each offering a stateless, deterministic approach to phrased modulation:
+FPS-R comprises three distinct mathematical algorithms — each offering a stateless, deterministic approach to phrased modulation:
 - 🌀 Stacked Modulo (SM)
 - 🔁 Toggled Modulo (TM)
 - ✴ Quantised Switching (QS)


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Updated README to reflect three FPS-R algorithms instead of two


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Corrected algorithm count from two to three</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Changed "two distinct mathematical algorithms" to "three distinct <br>mathematical algorithms" in FPS-R section</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/FPSR_Algorithm/pull/42/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

