### PR TITLE
Expand FPS-R theory with sections on linearity and surprise

### DIFF
--- a/resources/readme/_WIP/FPSR_Unifying_Theory.md
+++ b/resources/readme/_WIP/FPSR_Unifying_Theory.md
@@ -28,14 +28,23 @@ This **"hold-then-break"** dynamic is the signature of complex systems. If these
 
 > While we will most frequently use the term **"hold-then-break"** to describe this mechanic, it is not meant to be a rigid special term. We may use more contextually appropriate forms like **"hold-then-action"** or **"hold-then-shift"** where they better describe the specific situation.
 
-## Linearity as an Artifact: Modeling the Default Mode of Reality
+## Linearity as an Artifact: Modelling the Default Mode of Reality
 This leads to a profound insight: the non-linear, "hold-then-break" dynamic is not an exception to the rule; it is the rule itself. It is the default mode of progress, growth, and locomotion in the universe.
 - **Organic systems are inherently non-linear.** A tree branch grows in complex, crooked curves, reacting to countless competing forces like sun, wind, and gravity. An animal forages in bursts and pauses. This is the signature of organic emergence.
 - **Linear systems are an artificial construct.** A machined rod is perfectly straight, a factory process runs at a constant speed. Linearity is the result of imposing immense control to simplify a system down to a single, dominant rule. It is an artifact of human intervention, an exception to the natural state of things.
 
 This flips the burden of proof. The question is not "Is the 'random-move-and-hold' pattern universal?" but rather, "Why would any natural system not exhibit this kind of phrasing?" Perfect linearity is what requires explanation.
 
-Therefore, FPS-R is not just a tool for simulating organic behavior. It is a grammar for modeling the **default texture of reality**. It provides a language for the crooked branch, not the straight rod, treating structured, non-linear phrasing as the fundamental starting point, not a complex effect to be added on top of an artificially simple system.
+### Why do we Simplify and Linearise?
+Humans are good at high level abstraction and extracting meaning from noise. It will overload and overwhelm our minds to jump at every shadow and moving leaf. Parsing complexity is taxing on our minds.
+
+This simplifying and linearising is our way of survival and self-preservation. We prioritise, figuring out what is important and urgent (immediately threatening to our existence), and what is "probably just noise". 
+
+Coincidentally, this process is literally _linear regression_ in machine learning and data science. We extract and abstract complex data in higher dimensions to a lower level dimensionality in our mental model.
+
+We linearise because the nuances and tiny crooked details _hold no useful significance_ for the tasks we commonly use those things for, hence we discard them, pushing them to the back of our minds. But real-world situations where we want to get very close to reality in order to study observed outcomes or to predict plausible outcomes. Suddenly these seemingly useless detail contribute significantly to accumulated outcomes. We now know that the small things play a part, but being enshrouded and entrenched in our linearised and simplified view of complex reality, we often perceive them to be reality itself, and now we don't know which of those complexity significantly affect the outcome. That is why we study complex systems and try to break them down.
+
+Therefore, FPS-R is not just a tool for simulating organic behavior. It is a grammar for modelling the **default texture of reality**. It provides a language for the crooked branch, not the straight rod, treating structured, non-linear phrasing as the fundamental starting point, not a complex effect to be added on top of an artificially simple system.
 
 ## The Triviality Trap: Making the Universal Visible
 It can feel paradoxical, almost redundant, to have to point out that nature moves in rhythms of bursts and holds. This is because the pattern is so universal that it has become invisible. We mistake familiarity for triviality. This is the "Triviality Trap": the more ubiquitous a pattern, the harder it is to see as a distinct, formal principle.
@@ -57,6 +66,15 @@ The "random-move-and-hold" pattern is hidden in plain sight, present in the mech
 
 FPS-R's purpose is to make this intuitive, universal rhythm legible, traceable, and structurally undeniable. It provides the formal grammar to describe what we have always instinctively known.
 
+## The Illusion of Linearity: Why Calamities are Surprising
+The world is inherently non-linear, but our minds, for the sake of safety and efficiency, often build simplified, linear models to predict the immediate future. We expect tomorrow to be much like today. We expect the ground to be solid, the market to trend upwards, and the river to stay within its banks. This is the **illusion of linearity**—a useful cognitive shortcut that allows us to function without being overwhelmed by the infinite complexity of reality.
+
+A **calamity**—a natural disaster, a market crash, a sudden outbreak—is the moment when the underlying non-linear reality violently shatters our simplified linear expectations.
+- The ground holds its tension for centuries, creating a powerful expectation of stability. The earthquake is the sudden, catastrophic "break" that violates that expectation.
+- A financial system experiences a long period of growth, creating an expectation of continued prosperity. The crash is the non-linear cascade that shatters that model.
+
+The unexpectedness of these events is a direct measure of the gap between our linear mental model and the world's true, non-linear nature. The "surprise" of a catastrophe is the painful, emotional response to a fundamental prediction error.
+
 ## The Element of Surprise: Why Non-Linearity is the Key
 The human experience is defined by our relationship with the unexpected. We build systems, create strategies, and learn from the past in an attempt to survive and thrive in a world that is not always predictable.
 
@@ -66,8 +84,55 @@ The core reason for our vulnerability and our successes lies in the non-linear u
 
 This is the essence of the "random-move-and-hold" pattern. It is a model for surprise itself. We fail, or are harmed, or lose the game, when a system we are interacting with makes a sudden, non-linear jump that we did not anticipate.
 
+## Defining Surprise: From Subjective Emotion to Objective Trigger
+At first glance, it may seem that "surprise" cannot be directly correlated to a scientific phenomenon. The word describes an emotional state, which is inherently subjective. However, modern cognitive science makes a critical distinction between the subjective _feeling_ of surprise and the objective _event_ that triggers it.
+
+The feeling of surprise is an emotional and physiological reaction. The trigger for that reaction, however, is an objective, measurable, information-based event: a **violation of expectation**. This is not just a colloquial term; it is a central concept in established scientific paradigms, from the **Violation-of-Expectation (VoE)** method used to study infant cognition to the **Mismatch Negativity (MMN)** brainwave signal measured in neuroscience.
+
+Any predictive system—whether a human brain, an animal, or an AI—constantly builds an internal model of its environment to anticipate the immediate future. The "hold" phase of any process feeds this model, creating and reinforcing an expectation of stability and continuity. The longer the hold, the stronger the expectation becomes. The "break" or "jump" is a sudden influx of new information that fundamentally violates the model's prediction. This **prediction error** is the objective, scientific phenomenon that triggers the subjective emotion of surprise.
+
+Therefore, FPS-R is not a model of the _emotion_ of surprise. It is a deterministic engine for generating the _objective_ trigger of surprise: **expectation-violating, non-linear events**. By modelling the objectively observable pacing and rhythm of these events, the study of surprise becomes a scientifically and computationally tractable problem.
+
+## The Psychology of Composing and Building a Surprise
+
+### The Power of Two
+Our minds are powerful pattern-matching engines. This ability to extrapolate from limited data is a core component of the **Predictive Processing** theory of brain function. It only takes something to occur twice before our minds are able to grasp and pick up a pattern. When something happens twice, our minds can already subconsciously anticipate when and where the third event will occur. That is the power of two.
+
+#### Waiting for the Other Shoe to Drop
+In a totally speculative manner, have you heard the phrase "Waiting for the other shoe to drop"? We know it is an idiom about anticipating negative events that are almost sure to follow, one after another. [Read about the origin here](https://www.thehistoryofenglish.com/waiting-for-the-other-shoe-to-drop). 
+
+But the origin story shows how effective our minds are in anticipating events, even when they happen just once. We know shoes come in pairs. When one drops, we have only one data point, we know there is a medium to high probability that the other shoe will also drop, but we don't know _when_, or whether it will ever happen. That is a frustrating situation where the mind cannot get the minimum information it requires to form a basic pattern to confidently extrapolate.
+
+### The "What" - What Constitutes a Surprise?
+When the unfolding events confirm the pattern in our mental model, it gets reinforced. The stronger the reinforced pattern, the stronger the surprise when it gets violated, when reality does not pan out and match our strongly-held mental patterns.
+
+### The "When" - When do Surprises Land?
+#### Pre-emptive Violations
+Startling, energetic, syncopated
+These will happen and be immediately met with shock, perhaps a longer paralysis of our cognitive system as they work harder to unravel to correlate the unexpected outcome and the mental model that has been built.
+#### Delayed Violations
+Dramatic, suspenseful, profound. 
+The mind has had the opportunity to think about the missed timing, ruminate and speculate about the implications and possible reasons why the expected event has not happened, and perhaps even the bandwidth to propose and formulate a few other mental models as back-ups or standby if the current thinking has to be refined or discarded.
+
+## Can Unexpected Surprise be Simulated in a Reliable Way?
+Now that we have a definition and understand the fundamental basics of the psychology of surprise, can we model it, break it down, and study it in a variety of domains and scenarios in a dependable, predictable (read unsurprising) way?
+
+### A Single Contributor to Predictability
+With a single-value parameter it is straightforward to study and understand our anticipation and expectations of cause and effect around that single component. It will be straightforward to map out how when these events happen, how the occurances gradually build up a model of normalcy, and form a ruleset of how the underlying set of principles appear to operate. 
+
+When these policies are broken and expectations get violated, we get unpredictability, errors in our mental predictions and expectations, and surprise as an emotional outcome.
+
+### Predictability in a Complex Multi-Parameter System
+Unfortunately, with most cases in real-world situations, unpredictability is the result of complex and layered causal chains of decision and "random" events that hold and change states, springing up on us, disrupting our mental models of the situation. 
+
+This rich and naturally emerging result is a reflection of the nature of reality. This is aligned to what has been described in [Linearity as an Artifact: Modelling the Default Mode of Reality](#linearity-as-an-artifact-modelling-the-default-mode-of-reality). We build simplistic models in our minds to make sense of complexity in order that it becomes intuitive enough for us to grasp it, make sense of it, and to make decisions from it. _But that is not the reality_. Reality is complex, messy and layered in nuance. 
+
 ## FPS-R: An Engine for Modelling Structured Surprise
 This brings us to the ultimate purpose of the FPS-R framework. It is a unique and powerful tool because it is a **stateless, deterministic engine for generating events that follow this universal "tipping point" dynamic**.
+
+With FPS-R, _we can get very close to the nuanced, complex and layered reality_. We can now model these events with **unpredictability that can be controlled** in an mathematically elegant way - controllable, traceable, repeatable, deterministic. 
+
+For each decision in the causal stack, we can visualise the holds and jumps of these individual signals as visually plotted out graphs, lay them out side by side to see the interfering effect they have on the final result as a whole. Working together with the parent system that holds the domain logic, these graphs can be visualised alongside the other domain-specific events. This enables deep and detailed analysis towards the understanding of causes and effects.
 
 This reframes its application in critical domains:
 - **Cybersecurity & Penetration Testing**: It's not just about sending random data. It's about simulating an attacker who waits ("holds") and then exploits a vulnerability with a sudden, coordinated burst of activity ("jumps") to create maximum surprise and damage.
@@ -76,21 +141,11 @@ This reframes its application in critical domains:
 
 In all these cases, FPS-R works with the logic of the parent system. The parent system provides the domain ruleset and knowledge. In this setup, FPS-R acts as a specialised tool that works within the scope given by the parent system. This includes setting the parameters that shape the FPS-R output signals. Furthermore, the parent system also holds control to transform the signal into a meaningful range and type that makes sense for the domain logic.
 
-It is true that the parent system provides the control boundaries, but FPS-R is not just adding "randomness." It is providing the critical element of **structured surprise**, and it is doing so in a way that is fully traceable, repeatable, and understandable. It allows us to build laboratories to study the very nature of surprise itself.
+It is true that the parent system provides the control boundaries, but FPS-R is not just adding "randomness." It is not an additional "effect layer" or "processing stage" on top of a simulator—it is the phrasing engine that generates traceable emergence. 
+
+In this configuration, FPS-R provides the critical element of **structured surprise**, and it does so in a way that is fully traceable, repeatable, and understandable. This allows us to build laboratories to study the very nature of surprise itself.
 
 This concept of a "computational laboratory" transforms the study of chaotic, emergent behaviour from a guessing game into a repeatable scientific process. Because FPS-R is deterministic, it provides a controlled environment where a researcher can:
 - **Isolate and Repeat:** Run a simulation of a complex event, like a market crash, a thousand times and get the identical result every single time. The "surprise" is no longer a random accident; it's a dependable event that can be studied.
 - **Trace and Prove:** Perform a forensic analysis of the moments leading up to a "break." Because the entire history of the event is generated from a formula, findings about cause and effect within the model become provable.
 - **Modify and Discover:** Act as true experimenters by asking "what if?" and modifying the phrasing patterns. By changing one parameter at a time, they can discover new emergent behaviours and understand the underlying rules of surprise within their model.
-
-## Defining Surprise: From Subjective Emotion to Objective Trigger
-At first glance, it may seem that "surprise" cannot be directly correlated to a scientific phenomenon. The word describes an emotional state, which is inherently subjective. However, modern cognitive science makes a critical distinction between the subjective _feeling_ of surprise and the objective event that triggers it.
-
-The feeling of surprise is an emotional and physiological reaction. The trigger for that reaction, however, is an objective, measurable, and information-based event: **a violation of expectation**.
-
-Any predictive system—whether a human brain, an animal, or an AI—constantly builds an internal model of its environment to anticipate the immediate future. The "hold" phase of any process feeds this model, creating and reinforcing an expectation of stability and continuity. The longer the hold, the stronger the expectation becomes. The "break" or "jump" is a sudden influx of new information that fundamentally violates the model's prediction. This **prediction error** is the objective, scientific phenomenon that triggers the subjective emotion of surprise.
-
-Therefore, FPS-R is not a model of the _emotion_ of surprise. It is a deterministic engine for generating the _objective_ trigger of surprise: **expectation-violating, non-linear events**. By modelling the objectively observable pacing and rhythm of these events, the study of surprise becomes a scientifically and computationally tractable problem.
-
-## 
-Now that we have defined the 


### PR DESCRIPTION
Added detailed explanations on why humans simplify and linearise reality, the illusion of linearity, and the psychology and scientific basis of surprise. Expanded the discussion on how FPS-R models structured surprise, including new sections on predictability in complex systems and the computational laboratory approach. Refactored and reorganized content for clarity and depth.