### PR TITLE
updated readme.md  visualisation videos for better layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ _[Eyeball model](#https://sketchfab.com/3d-models/simple-stylised-eye-c26043a12a
 Here is a collection of visualisations showing how FPS-R can work within larger systems in different contexts to achieve meaningful behaviour. Mostly created in Houdini, posted on YouTube as videos, and as articles on LinkedIn.
 
 [LinkedIn Article: FPS-R Test: Rat Movement Demo](https://www.linkedin.com/pulse/fps-r-test-rat-movement-demo-patrick-woo-ker-yang-i7foc)
-[YouTube - Rat Demo](https://youtu.be/ZHUvv6YxjKw)
+[YouTube - Rat Demo](https://youtu.be/ZHUvv6YxjKw)  
 <img src="https://media.licdn.com/dms/image/v2/D5612AQEOZ-WhINj_Dg/article-cover_image-shrink_600_2000/B56ZfhTq9oHUAQ-/0/1751831721665?e=1757548800&v=beta&t=Af8C2WN0524qRF_labYDXIcyIXj9BuYeBSCezvoAHCo" alt="'article banner" width="260" height="160">
 
 [LinkedIn Article: The Straight Line and the Crooked Path: FPS-R, A New Model for Simulating Reality](https://www.linkedin.com/pulse/straight-line-crooked-path-fps-r-new-model-simulating-woo-ker-yang-ha9rc)
-[YouTube - FPS-R as a Moving Target on Swarm](https://youtu.be/uQ7krluFvic)
+[YouTube - FPS-R as a Moving Target on Swarm](https://youtu.be/uQ7krluFvic)  
 <img src="https://media.licdn.com/dms/image/v2/D5612AQEqDyv-WbKPGg/article-cover_image-shrink_720_1280/B56ZfoU1KLHUAQ-/0/1751949467407?e=1757548800&v=beta&t=GDBWV6AvcwTgWSQzwWcK_khENyFQ3D8DhrH1RmDVxSk" alt="'article banner" width="260" height="160">
 
 ---


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added trailing spaces after YouTube video links for improved formatting


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Format YouTube video links with trailing spaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added trailing spaces after two YouTube video links<br> <li> Improved visual layout and formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/patwooky/FPSR_Algorithm/pull/62/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

